### PR TITLE
Initial ESInt from ESString - matches PHP casting better

### DIFF
--- a/src/ESInt.php
+++ b/src/ESInt.php
@@ -35,6 +35,9 @@ class ESInt implements Shooped, Countable, Toggle, Shuffle
         if (is_int($int)) {
             $this->value = $int;
 
+        } elseif (is_string($int)) {
+            $this->value = intval($int);
+
         } elseif (is_a($int, ESInt::class)) {
             $this->value = $int->unfold();
 

--- a/src/ESString.php
+++ b/src/ESString.php
@@ -68,7 +68,7 @@ class ESString implements
 
     public function int(): ESInt
     {
-        return ESInt::fold(count($this->array()->unfold()));
+        return ESInt::fold(intval($this->unfold()));
     }
 
     public function dictionary(): ESDictionary

--- a/tests/IntTest.php
+++ b/tests/IntTest.php
@@ -1,0 +1,33 @@
+<?php
+namespace Eightfold\Shoop\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+use Eightfold\Shoop\Helpers\Type;
+
+use Eightfold\Shoop\Shoop;
+
+use Eightfold\Shoop\ESInt;
+
+class IntTest extends TestCase
+{
+    public function testCanInitialize()
+    {
+        $expected = 5;
+
+        $actual = (new ESInt($expected))->unfold();
+        $this->assertEquals($expected, $actual);
+
+        $actual = (new ESInt("5"))->unfold();
+        $this->assertEquals($expected, $actual);
+
+        $actual = Shoop::int($expected)->unfold();
+        $this->assertEquals($expected, $actual);
+
+        $actual = Shoop::int("5")->unfold();
+        $this->assertEquals($expected, $actual);
+
+        $actual = Shoop::int("05")->unfold();
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/tests/StringTest.php
+++ b/tests/StringTest.php
@@ -47,6 +47,11 @@ class StringTest extends TestCase
         $string = '{"one":2}';
         $actual = Shoop::string($string)->json();
         $this->assertEquals($string, $actual->unfold());
+
+        $string = "05";
+        $expected = 5;
+        $actual = Shoop::string($string);
+        $this->assertEquals($expected, $actual->unfold());
     }
 
     public function testManipulate()

--- a/tests/TypeJugglingTest.php
+++ b/tests/TypeJugglingTest.php
@@ -38,8 +38,9 @@ class TypeJugglingTest extends TestCase
     	$object = $string->object();
     	$this->assertEquals($base, $object->scalar);
 
-    	$int = $string->int();
-    	$this->assertEquals(13, $int->unfold());
+        $sInt = "05";
+    	$int = Shoop::string($sInt)->int();
+    	$this->assertEquals(5, $int->unfold());
 
     	$bool = $string->bool();
     	$this->assertEquals(true, $bool->unfold());


### PR DESCRIPTION
Breaking change

Before:

```
Shoop::string("05")->int();
// 2
```

After:

```
Shoop::string("05")->int();
// 5
```

PHP:

```
echo intval("05");
echo (int) "05";
// 5
```