### PR TITLE
Add summed() to ESArray - for arrays of integers

### DIFF
--- a/src/ESArray.php
+++ b/src/ESArray.php
@@ -298,7 +298,7 @@ class ESArray implements
         foreach ($this->unfold() as $int) {
             $total += Type::sanitizeType($int, ESInt::class)->unfold();
         }
-        return $total;
+        return Shoop::int($total);
     }
 
 //-> Getters

--- a/src/ESArray.php
+++ b/src/ESArray.php
@@ -292,6 +292,15 @@ class ESArray implements
         return Shoop::array($build);
     }
 
+    public function summed()
+    {
+        $total = 0;
+        foreach ($this->unfold() as $int) {
+            $total += Type::sanitizeType($int, ESInt::class)->unfold();
+        }
+        return $total;
+    }
+
 //-> Getters
     // public function __call(string $name, array $args = [])
     // {

--- a/tests/ArrayTest.php
+++ b/tests/ArrayTest.php
@@ -141,5 +141,9 @@ class ArrayTest extends TestCase
             $count++;
         }
         $this->assertTrue($count > 1);
+
+        $expected = 6;
+        $actual = Shoop::array([1, 2, 3])->summedUnfolded();
+        $this->assertEquals($expected, $actual);
     }
 }

--- a/tests/ArrayTest.php
+++ b/tests/ArrayTest.php
@@ -143,7 +143,7 @@ class ArrayTest extends TestCase
         $this->assertTrue($count > 1);
 
         $expected = 6;
-        $actual = Shoop::array([1, 2, 3])->summedUnfolded();
-        $this->assertEquals($expected, $actual);
+        $actual = Shoop::array([1, 2, 3])->summed();
+        $this->assertEquals($expected, $actual->unfold());
     }
 }


### PR DESCRIPTION
Was using `each()` to generate an array of integers. Didn't want to have to leave Shoop to add them together.

Returns ESInt

Might be interesting to create a `concatenated()` or something for strings...implementation could almost be the same.